### PR TITLE
Fix: Comply to App Store's Guideline

### DIFF
--- a/soap/Features/Settings/SettingsView.swift
+++ b/soap/Features/Settings/SettingsView.swift
@@ -27,7 +27,7 @@ struct SettingsView: View {
   
   private var appSettings: some View {
     Button("Change Language", systemImage: "globe") {
-      UIApplication.shared.open(URL(string: "App-prefs:org.sparcs.soap")!)
+      UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
     }
   }
 }


### PR DESCRIPTION
app-prefs: url scheme is private API, thus it does not comply with App Store's guidelines 