### PR TITLE
fix warnings

### DIFF
--- a/BuddyDomain/Sources/Status.swift
+++ b/BuddyDomain/Sources/Status.swift
@@ -11,7 +11,7 @@ public enum Status {
   // App Status
   public static let isProduction: Bool = {
     // Custom status
-    return true
+//    return true
 
     #if DEBUG
     return false

--- a/BuddyFeature/Sources/BuddyFeatureTaxi/BuddyTaxiChatUI/ChatRenderItemBuilder.swift
+++ b/BuddyFeature/Sources/BuddyFeatureTaxi/BuddyTaxiChatUI/ChatRenderItemBuilder.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import BuddyDomain
-import Playgrounds
 
 struct ChatRenderItemBuilder {
   let policy: ChatGroupingPolicy
@@ -124,15 +123,5 @@ struct ChatRenderItemBuilder {
     flushCluster()
     return items
   }
-}
-
-#Playground {
-  let mock: [TaxiChat] = TaxiChat.mockList
-  let builder = ChatRenderItemBuilder(
-    policy: TaxiGroupingPolicy(),
-    positionResolver: ChatBubblePositionResolver(),
-    presentationPolicy: DefaultMessagePresentationPolicy()
-  )
-  _ = builder.build(chats: mock, myUserID: "user2")
 }
 

--- a/BuddyFeature/Sources/BuddyFeatureTaxi/TaxiChat/TaxiChatViewModel.swift
+++ b/BuddyFeature/Sources/BuddyFeatureTaxi/TaxiChat/TaxiChatViewModel.swift
@@ -75,7 +75,6 @@ class TaxiChatViewModel: TaxiChatViewModelProtocol {
         let filtered = chats.filter { $0.roomID == self.room.id }
         let builtItems = self.renderItemBuilder.build(chats: filtered, myUserID: self.taxiUser?.oid)
         self.renderItems = builtItems
-        print("[HERE] \(self.renderItems)")
         self.state = .loaded
       }
       .store(in: &cancellables)

--- a/BuddyFeature/Sources/BuddyFeatureTimetable/LectureDetail/LectureDetailView.swift
+++ b/BuddyFeature/Sources/BuddyFeatureTimetable/LectureDetail/LectureDetailView.swift
@@ -52,10 +52,6 @@ struct LectureDetailView: View {
       await reviewsFetch
 
       canWriteReview = viewModel.course?.history.first(where: { $0.myLectureID != nil }) != nil
-      print(canWriteReview)
-      print(viewModel.course)
-      print(viewModel.course?.history.first(where: { $0.myLectureID != nil }))
-      print("shit")
     }
     .navigationTitle(lecture.name)
     .navigationBarTitleDisplayMode(.inline)

--- a/BuddyUI/Package.swift
+++ b/BuddyUI/Package.swift
@@ -23,7 +23,8 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(path: "../BuddyDomain")
+    .package(path: "../BuddyDomain"),
+    .package(url: "https://github.com/efremidze/Haptica.git", .upToNextMajor(from: "4.0.1")),
   ],
   targets: [
     .target(
@@ -37,12 +38,14 @@ let package = Package(
       dependencies: [
         "TimetableUI",
         "BuddyDomain",
+        "Haptica",
       ]
     ),
     .target(
       name: "TimetableUI",
       dependencies: [
         "BuddyDomain",
+        "Haptica",
       ]
     ),
     .testTarget(

--- a/WatchBuddy Watch App/ContentView.swift
+++ b/WatchBuddy Watch App/ContentView.swift
@@ -16,7 +16,6 @@ struct ContentView: View {
   @State private var items: [LectureItem] = []
 
   private var timetable: Timetable? {
-    print(timetableData)
     guard !timetableData.isEmpty else { return nil }
     return try? JSONDecoder().decode(Timetable.self, from: timetableData)
   }


### PR DESCRIPTION
This pull request primarily focuses on code cleanup and dependency management across several modules. The most significant changes include removing debug print statements, cleaning up playground/testing code, and adding a new third-party dependency for haptic feedback.

**Code cleanup and removal of debug/testing code:**

* Removed multiple debug print statements from `LectureDetailView.swift`, `TaxiChatViewModel.swift`, and `ContentView.swift` to clean up console output. [[1]](diffhunk://#diff-bbf0e49fb13e2e57d08f6b762072a93e746ced80b680f7b61353f3fc2db4adf6L55-L58) [[2]](diffhunk://#diff-90a966d897d799bd137d7ace6eb4e958bcf0ece4e6cc91a460d454465586325eL78) [[3]](diffhunk://#diff-27ae419c34b3574d56e91c86b0e1b99e8c64ef83410c6570147ddcce7bfefaf3L19)
* Removed a playground/testing block and the unnecessary import of `Playgrounds` from `ChatRenderItemBuilder.swift`, streamlining the file for production code. [[1]](diffhunk://#diff-49767563846e445da1b209b1852285c2319b1406ca6173fc2965aadc555867f4L10) [[2]](diffhunk://#diff-49767563846e445da1b209b1852285c2319b1406ca6173fc2965aadc555867f4L129-L138)

**Dependency management:**

* Added the `Haptica` package as a dependency to `BuddyUI/Package.swift` and included it in the dependencies of relevant targets, enabling haptic feedback features. [[1]](diffhunk://#diff-e2b4c8ba50628d6ab7ebea0872b663978075f6a58aafcb478dfa43c675a314c8L26-R27) [[2]](diffhunk://#diff-e2b4c8ba50628d6ab7ebea0872b663978075f6a58aafcb478dfa43c675a314c8R41-R48)

**Configuration adjustment:**

* Commented out the default return value in the `Status.swift` `isProduction` property, likely to clarify environment-specific behavior.