### PR TITLE
Reloads Widget Timeline on Timetable Data Changes

### DIFF
--- a/BuddyDataiOS/Sources/BuddyDataiOS/UseCase/AuthUseCase.swift
+++ b/BuddyDataiOS/Sources/BuddyDataiOS/UseCase/AuthUseCase.swift
@@ -11,6 +11,7 @@ import Observation
 import Synchronization
 import BuddyDomain
 import BuddyDataCore
+import WidgetKit
 
 @Observable
 public final class AuthUseCase: AuthUseCaseProtocol, @unchecked Sendable {
@@ -246,6 +247,7 @@ public final class AuthUseCase: AuthUseCaseProtocol, @unchecked Sendable {
   }
 
   public func signOut() async throws {
+		WidgetCenter.shared.reloadAllTimelines()
     tokenStorage.clearTokens()
     _isAuthenticatedSubject.value = false
     cancelRefreshTimer()

--- a/BuddyDataiOS/Sources/BuddyDataiOS/UseCase/AuthUseCase.swift
+++ b/BuddyDataiOS/Sources/BuddyDataiOS/UseCase/AuthUseCase.swift
@@ -236,6 +236,7 @@ public final class AuthUseCase: AuthUseCaseProtocol, @unchecked Sendable {
 
       _isAuthenticatedSubject.value = true
       print("[AuthUseCase] Signed In")
+			WidgetCenter.shared.reloadAllTimelines()
       scheduleRefreshTimer() // set timer on success
     } catch {
       tokenStorage.clearTokens()

--- a/BuddyFeature/Sources/BuddyFeatureTimetable/Timetable/TimetableViewModel.swift
+++ b/BuddyFeature/Sources/BuddyFeatureTimetable/Timetable/TimetableViewModel.swift
@@ -9,13 +9,14 @@ import SwiftUI
 import Observation
 import Factory
 import BuddyDomain
+import WidgetKit
 
 @MainActor
 @Observable
 public final class TimetableViewModel {
   @ObservationIgnored @Injected(
     \.v2TimetableUseCase
-  ) private var v2TimetableUseCase: TimetableUseCaseProtocol?
+  ) private var timetableUseCase: TimetableUseCaseProtocol?
   @ObservationIgnored @Injected(
     \.crashlyticsService
   ) private var crashlyticsService: CrashlyticsServiceProtocol?
@@ -78,7 +79,7 @@ public final class TimetableViewModel {
   public init() { }
 
   public func setup() async {
-    guard let timetableUseCase = v2TimetableUseCase else { return }
+    guard let timetableUseCase else { return }
 
     isLoading = true
     defer { isLoading = false }
@@ -97,7 +98,7 @@ public final class TimetableViewModel {
   }
 
   func addLecture(lecture: Lecture) async {
-    guard let timetableUseCase = v2TimetableUseCase,
+    guard let timetableUseCase,
           let selectedTimetableID else { return }
 
     do {
@@ -107,6 +108,7 @@ public final class TimetableViewModel {
       timetableLoadTask = Task {
         await loadTimetable()
       }
+			WidgetCenter.shared.reloadAllTimelines()
     } catch {
       crashlyticsService?.recordException(error: error)
       alertState = .init(
@@ -118,7 +120,7 @@ public final class TimetableViewModel {
   }
 
   func deleteLecture(lecture: Lecture) async {
-    guard let timetableUseCase = v2TimetableUseCase,
+    guard let timetableUseCase,
           let selectedTimetableID else { return }
 
     do {
@@ -128,6 +130,7 @@ public final class TimetableViewModel {
       timetableLoadTask = Task {
         await loadTimetable()
       }
+			WidgetCenter.shared.reloadAllTimelines()
     } catch {
       crashlyticsService?.recordException(error: error)
       alertState = .init(
@@ -139,7 +142,7 @@ public final class TimetableViewModel {
   }
 
   func loadTimetable() async {
-    guard let timetableUseCase = v2TimetableUseCase else { return }
+    guard let timetableUseCase else { return }
 
     do {
       let result: Timetable
@@ -156,6 +159,7 @@ public final class TimetableViewModel {
       try Task.checkCancellation()
 
       timetable = result
+			WidgetCenter.shared.reloadAllTimelines()
     } catch is CancellationError {
       // ignore
     } catch {
@@ -165,7 +169,7 @@ public final class TimetableViewModel {
   }
 
   func updateTimetableList() async {
-    guard let timetableUseCase = v2TimetableUseCase,
+    guard let timetableUseCase,
           let selectedSemester
     else { return }
 
@@ -183,7 +187,7 @@ public final class TimetableViewModel {
   }
 
   func renameTable(title: String) async {
-    guard let timetableUseCase = v2TimetableUseCase,
+    guard let timetableUseCase,
           let selectedTimetableID
     else { return }
 
@@ -201,6 +205,7 @@ public final class TimetableViewModel {
       timetableListTask = Task {
         await updateTimetableList()
       }
+			WidgetCenter.shared.reloadAllTimelines()
     } catch {
       crashlyticsService?.recordException(error: error)
       alertState = .init(
@@ -212,7 +217,7 @@ public final class TimetableViewModel {
   }
 
   func deleteTable() async {
-    guard let timetableUseCase = v2TimetableUseCase,
+    guard let timetableUseCase,
           let selectedTimetableID
     else { return }
 
@@ -227,6 +232,7 @@ public final class TimetableViewModel {
       timetableListTask = Task {
         await updateTimetableList()
       }
+			WidgetCenter.shared.reloadAllTimelines()
     } catch {
       crashlyticsService?.recordException(error: error)
       alertState = .init(
@@ -238,7 +244,7 @@ public final class TimetableViewModel {
   }
 
   func createTable() async {
-    guard let timetableUseCase = v2TimetableUseCase,
+    guard let timetableUseCase,
           let selectedSemester else { return }
 
     do {
@@ -249,6 +255,7 @@ public final class TimetableViewModel {
         await updateTimetableList()
         selectedTimetableID = creation.id
       }
+			WidgetCenter.shared.reloadAllTimelines()
     } catch {
       crashlyticsService?.recordException(error: error)
       alertState = .init(


### PR DESCRIPTION
This pull request adds widget update support and refactors variable naming in the timetable feature. The main functional improvement is that widgets are now refreshed automatically after key authentication and timetable operations, ensuring they always display up-to-date information. Additionally, the timetable view model code is simplified by standardizing the injected use case variable name.

**Widget update integration:**

* Added `WidgetKit` import and called `WidgetCenter.shared.reloadAllTimelines()` after sign in and sign out in `AuthUseCase`, so widgets reflect authentication changes immediately. [[1]](diffhunk://#diff-72388256c14755c71a2b3c42e64784eaf8624a8558e8fd5b984c2d153d096f9bR14) [[2]](diffhunk://#diff-72388256c14755c71a2b3c42e64784eaf8624a8558e8fd5b984c2d153d096f9bR239) [[3]](diffhunk://#diff-72388256c14755c71a2b3c42e64784eaf8624a8558e8fd5b984c2d153d096f9bR251)
* In `TimetableViewModel`, added `WidgetKit` import and updated widgets after adding, deleting, loading, renaming, creating, or deleting timetables or lectures, ensuring widget data stays in sync with user actions. [[1]](diffhunk://#diff-dfe3e5a2ce52cffeb9db7c767333bd8d4b51f266494540d1f841ea547668ac67R12-R19) [[2]](diffhunk://#diff-dfe3e5a2ce52cffeb9db7c767333bd8d4b51f266494540d1f841ea547668ac67R111) [[3]](diffhunk://#diff-dfe3e5a2ce52cffeb9db7c767333bd8d4b51f266494540d1f841ea547668ac67R133) [[4]](diffhunk://#diff-dfe3e5a2ce52cffeb9db7c767333bd8d4b51f266494540d1f841ea547668ac67R162) [[5]](diffhunk://#diff-dfe3e5a2ce52cffeb9db7c767333bd8d4b51f266494540d1f841ea547668ac67R208) [[6]](diffhunk://#diff-dfe3e5a2ce52cffeb9db7c767333bd8d4b51f266494540d1f841ea547668ac67R235) [[7]](diffhunk://#diff-dfe3e5a2ce52cffeb9db7c767333bd8d4b51f266494540d1f841ea547668ac67R258)

**Codebase simplification:**

* Renamed the injected timetable use case variable from `v2TimetableUseCase` to `timetableUseCase` and updated all references for clarity and consistency. [[1]](diffhunk://#diff-dfe3e5a2ce52cffeb9db7c767333bd8d4b51f266494540d1f841ea547668ac67R12-R19) [[2]](diffhunk://#diff-dfe3e5a2ce52cffeb9db7c767333bd8d4b51f266494540d1f841ea547668ac67L81-R82) [[3]](diffhunk://#diff-dfe3e5a2ce52cffeb9db7c767333bd8d4b51f266494540d1f841ea547668ac67L100-R101) [[4]](diffhunk://#diff-dfe3e5a2ce52cffeb9db7c767333bd8d4b51f266494540d1f841ea547668ac67L121-R123) [[5]](diffhunk://#diff-dfe3e5a2ce52cffeb9db7c767333bd8d4b51f266494540d1f841ea547668ac67L142-R145) [[6]](diffhunk://#diff-dfe3e5a2ce52cffeb9db7c767333bd8d4b51f266494540d1f841ea547668ac67L168-R172) [[7]](diffhunk://#diff-dfe3e5a2ce52cffeb9db7c767333bd8d4b51f266494540d1f841ea547668ac67L186-R190) [[8]](diffhunk://#diff-dfe3e5a2ce52cffeb9db7c767333bd8d4b51f266494540d1f841ea547668ac67L215-R220) [[9]](diffhunk://#diff-dfe3e5a2ce52cffeb9db7c767333bd8d4b51f266494540d1f841ea547668ac67L241-R247)

These changes improve both user experience (widgets update immediately after relevant actions) and code maintainability.