### PR TITLE
Adds LectureList View

### DIFF
--- a/BuddyDomain/Sources/Model/OTL/V2LectureClass.swift
+++ b/BuddyDomain/Sources/Model/OTL/V2LectureClass.swift
@@ -27,6 +27,10 @@ public struct LectureClass: Hashable, Sendable, Codable {
     }
     return "\(formatTime(begin))-\(formatTime(end))"
   }
+	
+	public var location: String {
+		"\(buildingCode) \(roomName)"
+	}
 
   public func statusString(at now: Date) -> String {
     let calendar = Calendar.current

--- a/BuddyFeature/Sources/BuddyFeatureTimetable/Localizable.xcstrings
+++ b/BuddyFeature/Sources/BuddyFeatureTimetable/Localizable.xcstrings
@@ -18,6 +18,34 @@
     "%lld" : {
       "shouldTranslate" : false
     },
+    "%lld Lectures" : {
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld Lecture"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld Lectures"
+                }
+              }
+            }
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld개의 강의"
+          }
+        }
+      }
+    },
     "A" : {
       "shouldTranslate" : false
     },
@@ -838,7 +866,20 @@
       }
     },
     "There is no lecture for this timetable." : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "There is no lecture for this timetable."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 시간표에는 강의가 없습니다."
+          }
+        }
+      }
     },
     "There was an error. Please try again later." : {
       "localizations" : {

--- a/BuddyFeature/Sources/BuddyFeatureTimetable/Localizable.xcstrings
+++ b/BuddyFeature/Sources/BuddyFeatureTimetable/Localizable.xcstrings
@@ -837,6 +837,9 @@
         }
       }
     },
+    "There is no lecture for this timetable." : {
+
+    },
     "There was an error. Please try again later." : {
       "localizations" : {
         "en" : {

--- a/BuddyFeature/Sources/BuddyFeatureTimetable/Timetable/Components/LectureList/LectureList.swift
+++ b/BuddyFeature/Sources/BuddyFeatureTimetable/Timetable/Components/LectureList/LectureList.swift
@@ -14,7 +14,7 @@ struct LectureList: View {
 	
 	var body: some View {
 		VStack(alignment: .leading) {
-			Text("^[\(lectures?.count ?? 0) Lecture](inflect: true)")
+			Text("\(lectures?.count ?? 0) Lectures", bundle: .module)
 				.font(.title3)
 				.fontWeight(.bold)
 			
@@ -35,7 +35,7 @@ struct LectureList: View {
 					}
 				}
 			} else {
-				Text("There is no lecture for this timetable.")
+				Text("There is no lecture for this timetable.", bundle: .module)
 					.padding()
 					.frame(maxWidth: .infinity)
 			}

--- a/BuddyFeature/Sources/BuddyFeatureTimetable/Timetable/Components/LectureList/LectureList.swift
+++ b/BuddyFeature/Sources/BuddyFeatureTimetable/Timetable/Components/LectureList/LectureList.swift
@@ -1,0 +1,49 @@
+//
+//  LectureList.swift
+//  BuddyFeature
+//
+//  Created by Soongyu Kwon on 5/8/26.
+//
+
+import SwiftUI
+import BuddyDomain
+
+struct LectureList: View {
+	let lectures: [Lecture]?
+	var selectedLecture: ((LectureItem) -> Void)?
+	
+	var body: some View {
+		VStack(alignment: .leading) {
+			Text("^[\(lectures?.count ?? 0) Lecture](inflect: true)")
+				.font(.title3)
+				.fontWeight(.bold)
+			
+			if let lectures, !lectures.isEmpty {
+				ForEach(Array(lectures.enumerated()), id: \.element.id) { index, lecture in
+					
+					LectureListRow(lecture: lecture)
+						.contentShape(.rect)
+						.onTapGesture {
+							guard let lectureClass = lecture.classes.first else { return }
+							let item = LectureItem(lecture: lecture, lectureClass: lectureClass)
+							selectedLecture?(item)
+						}
+					
+					if index != lectures.count - 1 {
+						Divider()
+							.padding(.leading, 20)
+					}
+				}
+			} else {
+				Text("There is no lecture for this timetable.")
+					.padding()
+					.frame(maxWidth: .infinity)
+			}
+		}
+	}
+}
+
+
+#Preview {
+	LectureList(lectures: Lecture.mockList, selectedLecture: nil)
+}

--- a/BuddyFeature/Sources/BuddyFeatureTimetable/Timetable/Components/LectureList/LectureListRow.swift
+++ b/BuddyFeature/Sources/BuddyFeatureTimetable/Timetable/Components/LectureList/LectureListRow.swift
@@ -1,40 +1,17 @@
 //
-//  LectureList.swift
+//  LectureListRow.swift
 //  BuddyFeature
 //
-//  Created by Soongyu Kwon on 5/8/26.
+//  Created by Soongyu Kwon on 5/9/26.
 //
 
 import SwiftUI
 import BuddyDomain
 
-struct LectureList: View {
-	let lectures: [Lecture]?
+struct LectureListRow: View {
+	let lecture: Lecture
 	
 	var body: some View {
-		VStack(alignment: .leading) {
-			Text("^[\(lectures?.count ?? 0) Lecture](inflect: true)")
-				.font(.title3)
-				.fontWeight(.bold)
-			
-			if let lectures, !lectures.isEmpty {
-				ForEach(Array(lectures.enumerated()), id: \.element.id) { index, lecture in
-					
-					makeRow(lecture: lecture)
-					
-					if index != lectures.count - 1 {
-						Divider()
-							.padding(.leading, 20)
-					}
-				}
-			} else {
-				Text("There is no lecture for this timetable.")
-					.frame(maxWidth: .infinity)
-			}
-		}
-	}
-	
-	func makeRow(lecture: Lecture) -> some View {
 		HStack(alignment: .center) {
 			Circle()
 				.frame(width: 12, height: 12)
@@ -66,7 +43,7 @@ struct LectureList: View {
 		}
 	}
 	
-	func makeLabel(_ text: String, systemImage: String) -> some View {
+	private func makeLabel(_ text: String, systemImage: String) -> some View {
 		HStack(alignment: .center, spacing: 4) {
 			Image(systemName: systemImage)
 			Text(text)
@@ -74,7 +51,7 @@ struct LectureList: View {
 		}
 	}
 	
-	func creditLabel(credits: Int, label: String) -> some View {
+	private func creditLabel(credits: Int, label: String) -> some View {
 		HStack(alignment: .bottom, spacing: 2) {
 			Text("\(credits)")
 				.fontDesign(.rounded)
@@ -84,9 +61,4 @@ struct LectureList: View {
 				.font(.caption)
 		}
 	}
-}
-
-
-#Preview {
-	LectureList(lectures: Lecture.mockList)
 }

--- a/BuddyFeature/Sources/BuddyFeatureTimetable/Timetable/Components/LectureList/LectureListRow.swift
+++ b/BuddyFeature/Sources/BuddyFeatureTimetable/Timetable/Components/LectureList/LectureListRow.swift
@@ -59,6 +59,7 @@ struct LectureListRow: View {
 			
 			Text(label)
 				.font(.caption)
+				.offset(y: -1)
 		}
 	}
 }

--- a/BuddyFeature/Sources/BuddyFeatureTimetable/Timetable/Components/TimetableList.swift
+++ b/BuddyFeature/Sources/BuddyFeatureTimetable/Timetable/Components/TimetableList.swift
@@ -1,0 +1,92 @@
+//
+//  LectureList.swift
+//  BuddyFeature
+//
+//  Created by Soongyu Kwon on 5/8/26.
+//
+
+import SwiftUI
+import BuddyDomain
+
+struct LectureList: View {
+	let lectures: [Lecture]?
+	
+	var body: some View {
+		VStack(alignment: .leading) {
+			Text("^[\(lectures?.count ?? 0) Lecture](inflect: true)")
+				.font(.title3)
+				.fontWeight(.bold)
+			
+			if let lectures, !lectures.isEmpty {
+				ForEach(Array(lectures.enumerated()), id: \.element.id) { index, lecture in
+					
+					makeRow(lecture: lecture)
+					
+					if index != lectures.count - 1 {
+						Divider()
+							.padding(.leading, 20)
+					}
+				}
+			} else {
+				Text("There is no lecture for this timetable.")
+					.frame(maxWidth: .infinity)
+			}
+		}
+	}
+	
+	func makeRow(lecture: Lecture) -> some View {
+		HStack(alignment: .center) {
+			Circle()
+				.frame(width: 12, height: 12)
+				.foregroundStyle(lecture.backgroundColor)
+			
+			VStack(alignment: .leading) {
+				Text(lecture.name)
+					.font(.headline)
+					.lineLimit(1)
+				
+				HStack {
+					makeLabel(lecture.code, systemImage: "text.book.closed")
+					makeLabel(lecture.professors.first?.name ?? "Unknown", systemImage: "person")
+					makeLabel(lecture.classes.first?.location ?? "Unknown", systemImage: "mappin.and.ellipse")
+				}
+				.font(.caption)
+				.foregroundStyle(.secondary)
+			}
+			
+			Spacer()
+			
+			if lecture.credit > 0 {
+				creditLabel(credits: lecture.credit, label: "CR")
+			}
+			
+			if lecture.creditAU > 0 {
+				creditLabel(credits: lecture.creditAU, label: "AU")
+			}
+		}
+	}
+	
+	func makeLabel(_ text: String, systemImage: String) -> some View {
+		HStack(alignment: .center, spacing: 4) {
+			Image(systemName: systemImage)
+			Text(text)
+				.lineLimit(1)
+		}
+	}
+	
+	func creditLabel(credits: Int, label: String) -> some View {
+		HStack(alignment: .bottom, spacing: 2) {
+			Text("\(credits)")
+				.fontDesign(.rounded)
+				.font(.title3)
+			
+			Text(label)
+				.font(.caption)
+		}
+	}
+}
+
+
+#Preview {
+	LectureList(lectures: Lecture.mockList)
+}

--- a/BuddyFeature/Sources/BuddyFeatureTimetable/Timetable/TimetableView.swift
+++ b/BuddyFeature/Sources/BuddyFeatureTimetable/Timetable/TimetableView.swift
@@ -62,10 +62,15 @@ public struct TimetableView: View {
             .glassEffect(colorScheme == .light ? .identity : .regular, in: .rect(cornerRadius: 28))
             .frame(height: reader.size.height * 0.8)
 						
-						LectureList(lectures: viewModel.timetable?.lectures)
-							.padding()
-							.background(colorScheme == .light ? Color.secondarySystemGroupedBackground : .clear, in: .rect(cornerRadius: 28))
-							.glassEffect(colorScheme == .light ? .identity : .regular, in: .rect(cornerRadius: 28))
+						LectureList(
+							lectures: viewModel.timetable?.lectures,
+							selectedLecture: { selectedLecture in
+								self.selectedLecture = selectedLecture
+							}
+						)
+						.padding()
+						.background(colorScheme == .light ? Color.secondarySystemGroupedBackground : .clear, in: .rect(cornerRadius: 28))
+						.glassEffect(colorScheme == .light ? .identity : .regular, in: .rect(cornerRadius: 28))
 
             TimetableCreditGraph(selectedTimetable: viewModel.timetable)
               .padding()

--- a/BuddyFeature/Sources/BuddyFeatureTimetable/Timetable/TimetableView.swift
+++ b/BuddyFeature/Sources/BuddyFeatureTimetable/Timetable/TimetableView.swift
@@ -61,6 +61,11 @@ public struct TimetableView: View {
             .background(colorScheme == .light ? Color.secondarySystemGroupedBackground : .clear, in: .rect(cornerRadius: 28))
             .glassEffect(colorScheme == .light ? .identity : .regular, in: .rect(cornerRadius: 28))
             .frame(height: reader.size.height * 0.8)
+						
+						LectureList(lectures: viewModel.timetable?.lectures)
+							.padding()
+							.background(colorScheme == .light ? Color.secondarySystemGroupedBackground : .clear, in: .rect(cornerRadius: 28))
+							.glassEffect(colorScheme == .light ? .identity : .regular, in: .rect(cornerRadius: 28))
 
             TimetableCreditGraph(selectedTimetable: viewModel.timetable)
               .padding()

--- a/BuddyUI/Sources/TimetableUI/TimetableGrid.swift
+++ b/BuddyUI/Sources/TimetableUI/TimetableGrid.swift
@@ -56,6 +56,7 @@ public struct TimetableGrid: View {
                 .frame(height: getHeight(for: item, in: geometry.size, of: selectedTimetable))
                 .offset(y: getOffset(for: item, in: geometry.size, of: selectedTimetable))
                 .transition(.scale.combined(with: .opacity))
+								.contentShape(.rect)
                 .onTapGesture {
                   Haptic.selection.generate()
                   selectedLecture?(item)


### PR DESCRIPTION
This pull request introduces a new `LectureList` component to the timetable feature, enhances localization for lecture-related UI, and improves the display of lecture details. The main changes add a structured and interactive lecture list, provide better internationalization, and refine how lecture information is presented in the UI.

**New UI Components:**
- Added a new `LectureList` SwiftUI view to display a list of lectures with selection handling, including a fallback message when there are no lectures (`LectureList.swift`).
- Introduced `LectureListRow` to present individual lecture details, including name, code, professor, location, and credits, with improved visual styling (`LectureListRow.swift`).

**Integration and UI Improvements:**
- Integrated `LectureList` into the main `TimetableView`, displaying the list below the timetable grid and handling lecture selection.
- Enhanced tap target for timetable grid items by adding `.contentShape(.rect)` for better gesture recognition.

**Localization and Data Enhancements:**
- Added localized strings for lecture counts (with pluralization) and empty state messages in both English and Korean (`Localizable.xcstrings`). [[1]](diffhunk://#diff-4a957bb6271cb1549f80d81fd3e92129adb0e83c811e47e7263c60dccb3001c8R21-R48) [[2]](diffhunk://#diff-4a957bb6271cb1549f80d81fd3e92129adb0e83c811e47e7263c60dccb3001c8R868-R883)
- Added a computed `location` property to `LectureClass` for consistent room display formatting (`V2LectureClass.swift`).