### PR TITLE
Hotfix: Handle Ara Boards without `group` Field

### DIFF
--- a/BuddyData/Sources/BuddyDataCore/Networking/ResponseDTO/Ara/AraBoardDTO.swift
+++ b/BuddyData/Sources/BuddyDataCore/Networking/ResponseDTO/Ara/AraBoardDTO.swift
@@ -14,7 +14,7 @@ public struct AraBoardDTO: Codable {
   public let koName: String
   public let enName: String
   public let isReadOnly: Bool
-  public let group: AraBoardGroupDTO
+  public let group: AraBoardGroupDTO?
   public let topics: [AraBoardTopicDTO]?
   public let userReadable: Bool?
   public let userWritable: Bool?
@@ -35,14 +35,16 @@ public struct AraBoardDTO: Codable {
 
 public extension AraBoardDTO {
   func toModel() -> AraBoard {
-    AraBoard(
+    let name = LocalizedString([
+      "ko": koName,
+      "en": enName
+    ])
+
+    return AraBoard(
       id: id,
       slug: slug,
-      name: LocalizedString([
-        "ko": koName,
-        "en": enName
-      ]),
-      group: group.toModel(),
+      name: name,
+      group: group?.toModel() ?? .empty,
       topics: topics?.compactMap { $0.toModel() },
       isReadOnly: isReadOnly,
       userReadable: userReadable,

--- a/BuddyDataiOS/Sources/BuddyDataiOS/Repository/Ara/AraBoardRepository.swift
+++ b/BuddyDataiOS/Sources/BuddyDataiOS/Repository/Ara/AraBoardRepository.swift
@@ -31,7 +31,9 @@ public final class AraBoardRepository: AraBoardRepositoryProtocol, @unchecked Se
     }
 
     let response = try await provider.request(.fetchBoards)
-    let boards: [AraBoard] = try response.map([AraBoardDTO].self).compactMap { $0.toModel() }
+    let boards: [AraBoard] = try response.map([AraBoardDTO].self)
+      .compactMap { $0.toModel() }
+      .filter { !$0.slug.contains("internal") } // FIXME: temporary workaround for filtering internal board
 
     cacheLock.withLock { self.cachedBoards = boards }
     return boards

--- a/BuddyDomain/Sources/Model/Ara/AraBoardGroup.swift
+++ b/BuddyDomain/Sources/Model/Ara/AraBoardGroup.swift
@@ -18,3 +18,10 @@ public struct AraBoardGroup: Identifiable, Hashable, Sendable {
     self.name = name
   }
 }
+
+public extension AraBoardGroup {
+  static let empty = Self(id: 999, slug: "extra", name: LocalizedString([
+    "ko": "기타",
+    "en": "Extra"
+  ]))
+}


### PR DESCRIPTION
* Ignore internal boards
* Use default group(`.empty`) for boards without `group` field