### PR TITLE
Clear TimetableCache on signOut

### DIFF
--- a/BuddyData/Sources/BuddyDataCore/Cache/TimetableCache.swift
+++ b/BuddyData/Sources/BuddyDataCore/Cache/TimetableCache.swift
@@ -68,4 +68,11 @@ public final class TimetableCache: Sendable {
     context.delete(existing)
     try? context.save()
   }
+	
+	/// Removes all cached timetable entries.
+	public func clear() {
+		let context = ModelContext(modelContainer)
+		try? context.delete(model: CachedTimetable.self)
+		try? context.save()
+	}
 }

--- a/BuddyDataiOS/Sources/BuddyDataiOS/UseCase/AuthUseCase.swift
+++ b/BuddyDataiOS/Sources/BuddyDataiOS/UseCase/AuthUseCase.swift
@@ -248,6 +248,9 @@ public final class AuthUseCase: AuthUseCaseProtocol, @unchecked Sendable {
   }
 
   public func signOut() async throws {
+		if let container = TimetableCacheContainer.shared {
+			TimetableCache(modelContainer: container).clear()
+		}
 		WidgetCenter.shared.reloadAllTimelines()
     tokenStorage.clearTokens()
     _isAuthenticatedSubject.value = false


### PR DESCRIPTION
This pull request introduces a mechanism to clear all cached timetable entries when a user signs out. The main changes include adding a `clear()` method to the `TimetableCache` class and updating the sign-out process to invoke this method, ensuring cached data is properly removed.

Timetable cache management:

* Added a `clear()` method to `TimetableCache` that deletes all `CachedTimetable` entries from the cache and saves the context.
* Updated the `signOut()` method in `AuthUseCase` to call `TimetableCache.clear()` if a cache container exists, ensuring cached timetable data is removed on sign-out.