### PR TITLE
Bump up version to v1.3.2

### DIFF
--- a/soap.xcodeproj/project.pbxproj
+++ b/soap.xcodeproj/project.pbxproj
@@ -890,7 +890,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.3.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.sparcs.soap.watchkitapp.BuddyWatchWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -926,7 +926,7 @@
 					"@executable_path/../../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.3.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.sparcs.soap.watchkitapp.BuddyWatchWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -962,7 +962,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.3.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.sparcs.soap.BuddyiOSWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -995,7 +995,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.3.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.sparcs.soap.BuddyiOSWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1030,7 +1030,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.3.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.sparcs.soap.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1071,7 +1071,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.3.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.sparcs.soap.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1244,7 +1244,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.3.2;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = org.sparcs.soap;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1288,7 +1288,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.3.2;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = org.sparcs.soap;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1396,7 +1396,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.3.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.sparcs.soap.NotificationServiceExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1428,7 +1428,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.3.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.sparcs.soap.NotificationServiceExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
This pull request updates the marketing version for all targets in the Xcode project from 1.3.1 to 1.3.2. No other changes were made. This is a standard version bump in preparation for a new release.

- Project configuration:
  * Updated the `MARKETING_VERSION` from `1.3.1` to `1.3.2` across all relevant targets in `soap.xcodeproj/project.pbxproj`. [[1]](diffhunk://#diff-1c8721cfd2cc03247a9ecdfc7d9153a770faa1e1caa910ba0b82d00956400a26L893-R893) [[2]](diffhunk://#diff-1c8721cfd2cc03247a9ecdfc7d9153a770faa1e1caa910ba0b82d00956400a26L929-R929) [[3]](diffhunk://#diff-1c8721cfd2cc03247a9ecdfc7d9153a770faa1e1caa910ba0b82d00956400a26L965-R965) [[4]](diffhunk://#diff-1c8721cfd2cc03247a9ecdfc7d9153a770faa1e1caa910ba0b82d00956400a26L998-R998) [[5]](diffhunk://#diff-1c8721cfd2cc03247a9ecdfc7d9153a770faa1e1caa910ba0b82d00956400a26L1033-R1033) [[6]](diffhunk://#diff-1c8721cfd2cc03247a9ecdfc7d9153a770faa1e1caa910ba0b82d00956400a26L1074-R1074) [[7]](diffhunk://#diff-1c8721cfd2cc03247a9ecdfc7d9153a770faa1e1caa910ba0b82d00956400a26L1247-R1247) [[8]](diffhunk://#diff-1c8721cfd2cc03247a9ecdfc7d9153a770faa1e1caa910ba0b82d00956400a26L1291-R1291) [[9]](diffhunk://#diff-1c8721cfd2cc03247a9ecdfc7d9153a770faa1e1caa910ba0b82d00956400a26L1399-R1399) [[10]](diffhunk://#diff-1c8721cfd2cc03247a9ecdfc7d9153a770faa1e1caa910ba0b82d00956400a26L1431-R1431)