### PR TITLE
Add collapsible feed posts and comments

### DIFF
--- a/BuddyFeature/Sources/BuddyFeatureFeed/Feed/Components/FeedPostRow.swift
+++ b/BuddyFeature/Sources/BuddyFeatureFeed/Feed/Components/FeedPostRow.swift
@@ -26,13 +26,16 @@ struct FeedPostRow: View {
   @State private var showTranslateSheet: Bool = false
   @State private var showPopover: Bool = false
   @State private var safariSheetURL: URL? = nil
+	@State private var isHiddenPostExpanded: Bool = false
 
   var body: some View {
     Group {
       VStack(alignment: .leading) {
         header
-
-        content
+				
+				if post.downvotes < 15 || isHiddenPostExpanded || showFullContent {
+					content
+				}
 
         footer
       }
@@ -111,43 +114,52 @@ struct FeedPostRow: View {
         .font(.callout)
 
       Spacer()
-
-      if onPostDeleted != nil {
-        Menu {
-          Button(String(localized: "Translate", bundle: .module), systemImage: "translate") { showTranslateSheet = true }
-          Divider()
-          if post.isAuthor {
-            Button(String(localized: "Delete", bundle: .module), systemImage: "trash", role: .destructive) {
-              showDeleteConfirmation = true
-            }
-          } else {
-            Menu(String(localized: "Report", bundle: .module), systemImage: "exclamationmark.triangle.fill") {
-              ForEach(FeedReportType.allCases) { reason in
-                Button(reason.description) {
-                  Task {
-                    await viewModel.reportPost(postID: post.id, reason: reason)
-                  }
-                }
-              }
-            }
-          }
-        } label: {
-          Label(String(localized: "More", bundle: .module), systemImage: "ellipsis")
-            .labelStyle(.iconOnly)
-            .padding(8)
-            .contentShape(.rect)
-        }
-        .confirmationDialog(String(localized: "Delete Post", bundle: .module), isPresented: $showDeleteConfirmation, titleVisibility: .visible) {
-          Button(String(localized: "Delete", bundle: .module), role: .destructive) {
-            Task {
-              onPostDeleted?(post.id)
-            }
-          }
-          Button(String(localized: "Cancel", bundle: .module), role: .cancel) { }
-        } message: {
-          Text("Are you sure you want to delete this post?", bundle: .module)
-        }
-      }
+			
+			if post.downvotes >= 15 && !isHiddenPostExpanded && !showFullContent {
+				Button(String(localized: "Expand", bundle: .module), systemImage: "chevron.right") {
+					isHiddenPostExpanded = true
+				}
+				.labelStyle(.iconOnly)
+				.padding(8)
+				.tint(.secondary)
+			} else {
+				if onPostDeleted != nil {
+					Menu {
+						Button(String(localized: "Translate", bundle: .module), systemImage: "translate") { showTranslateSheet = true }
+						Divider()
+						if post.isAuthor {
+							Button(String(localized: "Delete", bundle: .module), systemImage: "trash", role: .destructive) {
+								showDeleteConfirmation = true
+							}
+						} else {
+							Menu(String(localized: "Report", bundle: .module), systemImage: "exclamationmark.triangle.fill") {
+								ForEach(FeedReportType.allCases) { reason in
+									Button(reason.description) {
+										Task {
+											await viewModel.reportPost(postID: post.id, reason: reason)
+										}
+									}
+								}
+							}
+						}
+					} label: {
+						Label(String(localized: "More", bundle: .module), systemImage: "ellipsis")
+							.labelStyle(.iconOnly)
+							.padding(8)
+							.contentShape(.rect)
+					}
+					.confirmationDialog(String(localized: "Delete Post", bundle: .module), isPresented: $showDeleteConfirmation, titleVisibility: .visible) {
+						Button(String(localized: "Delete", bundle: .module), role: .destructive) {
+							Task {
+								onPostDeleted?(post.id)
+							}
+						}
+						Button(String(localized: "Cancel", bundle: .module), role: .cancel) { }
+					} message: {
+						Text("Are you sure you want to delete this post?", bundle: .module)
+					}
+				}
+			}
     }
     .padding(.horizontal)
   }

--- a/BuddyFeature/Sources/BuddyFeatureFeed/FeedPost/Components/FeedCommentRow.swift
+++ b/BuddyFeature/Sources/BuddyFeatureFeed/FeedPost/Components/FeedCommentRow.swift
@@ -25,6 +25,7 @@ struct FeedCommentRow: View {
   @State private var showTranslateSheet: Bool = false
   @State private var showPopover: Bool = false
   @State private var safariSheetURL: URL? = nil
+  @State private var isHiddenCommentExpanded: Bool = false
 
   var body: some View {
     HStack(alignment: .top, spacing: 8) {
@@ -35,7 +36,9 @@ struct FeedCommentRow: View {
       VStack(alignment: .leading) {
         header
 
-        content
+        if comment.downvotes < 15 || isHiddenCommentExpanded || showFullContent {
+          content
+        }
 
         footer
       }
@@ -118,31 +121,40 @@ struct FeedCommentRow: View {
 
       Spacer()
 
-      Menu {
-        Button(String(localized: "Translate", bundle: .module), systemImage: "translate") { showTranslateSheet = true }
-        Divider()
-        if comment.isMyComment {
-          Button(String(localized: "Delete", bundle: .module), systemImage: "trash", role: .destructive) {
-            Task {
-              await viewModel.delete(comment: $comment)
+      if comment.downvotes >= 15 && !isHiddenCommentExpanded && !showFullContent {
+        Button(String(localized: "Expand", bundle: .module), systemImage: "chevron.right") {
+          isHiddenCommentExpanded = true
+        }
+        .labelStyle(.iconOnly)
+        .padding(8)
+        .tint(.secondary)
+      } else {
+        Menu {
+          Button(String(localized: "Translate", bundle: .module), systemImage: "translate") { showTranslateSheet = true }
+          Divider()
+          if comment.isMyComment {
+            Button(String(localized: "Delete", bundle: .module), systemImage: "trash", role: .destructive) {
+              Task {
+                await viewModel.delete(comment: $comment)
+              }
             }
-          }
-        } else {
-          Menu(String(localized: "Report", bundle: .module), systemImage: "exclamationmark.triangle.fill") {
-            ForEach(FeedReportType.allCases) { reason in
-              Button(reason.description) {
-                Task {
-                  await viewModel.reportComment(commentID: comment.id, reason: reason)
+          } else {
+            Menu(String(localized: "Report", bundle: .module), systemImage: "exclamationmark.triangle.fill") {
+              ForEach(FeedReportType.allCases) { reason in
+                Button(reason.description) {
+                  Task {
+                    await viewModel.reportComment(commentID: comment.id, reason: reason)
+                  }
                 }
               }
             }
           }
+        } label: {
+          Label(String(localized: "More", bundle: .module), systemImage: "ellipsis")
+            .labelStyle(.iconOnly)
+            .padding(8)
+            .contentShape(.rect)
         }
-      } label: {
-        Label(String(localized: "More", bundle: .module), systemImage: "ellipsis")
-          .labelStyle(.iconOnly)
-          .padding(8)
-          .contentShape(.rect)
       }
     }
   }

--- a/BuddyFeature/Sources/BuddyFeatureFeed/Localizable.xcstrings
+++ b/BuddyFeature/Sources/BuddyFeatureFeed/Localizable.xcstrings
@@ -179,6 +179,9 @@
         }
       }
     },
+    "Expand" : {
+
+    },
     "Failed to downvote" : {
       "localizations" : {
         "en" : {

--- a/BuddyFeature/Sources/BuddyFeatureFeed/Localizable.xcstrings
+++ b/BuddyFeature/Sources/BuddyFeatureFeed/Localizable.xcstrings
@@ -180,7 +180,20 @@
       }
     },
     "Expand" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expand"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "확장"
+          }
+        }
+      }
     },
     "Failed to downvote" : {
       "localizations" : {


### PR DESCRIPTION
This pull request introduces a new feature that hides the content of posts and comments that have received 15 or more downvotes, replacing them with an "Expand" button. Users can reveal the hidden content by clicking "Expand." This helps improve the user experience by reducing the visibility of heavily downvoted content, while still allowing access if desired. The changes also add localization support for the "Expand" button.

**Hidden content for downvoted posts and comments:**

* [`FeedPostRow.swift`](diffhunk://#diff-e64e298a64812a6a3085885bd1cfb564ea8cc0044095b0234b79ab0b1e552b9aR29-R38): Content is hidden for posts with 15 or more downvotes, displaying an "Expand" button to reveal the content. [[1]](diffhunk://#diff-e64e298a64812a6a3085885bd1cfb564ea8cc0044095b0234b79ab0b1e552b9aR29-R38) [[2]](diffhunk://#diff-e64e298a64812a6a3085885bd1cfb564ea8cc0044095b0234b79ab0b1e552b9aR118-R125) [[3]](diffhunk://#diff-e64e298a64812a6a3085885bd1cfb564ea8cc0044095b0234b79ab0b1e552b9aR163)
* [`FeedCommentRow.swift`](diffhunk://#diff-ec22ecb9d27bbfb5eef02d74d98e3f5d1b62505ac546c77909cfe49849e86febR28): Content is hidden for comments with 15 or more downvotes, displaying an "Expand" button to reveal the content. [[1]](diffhunk://#diff-ec22ecb9d27bbfb5eef02d74d98e3f5d1b62505ac546c77909cfe49849e86febR28) [[2]](diffhunk://#diff-ec22ecb9d27bbfb5eef02d74d98e3f5d1b62505ac546c77909cfe49849e86febR39-R41) [[3]](diffhunk://#diff-ec22ecb9d27bbfb5eef02d74d98e3f5d1b62505ac546c77909cfe49849e86febR124-R131) [[4]](diffhunk://#diff-ec22ecb9d27bbfb5eef02d74d98e3f5d1b62505ac546c77909cfe49849e86febR160)

**Localization:**

* [`Localizable.xcstrings`](diffhunk://#diff-66e662ed91f3a5d4e8ee7ec8a3036fd20b015ffe5c1eb407f75712482d9f56deR182-R197): Added the "Expand" string with English and Korean translations for use in the new button.