### PR TITLE
Fix Dependency Issue on Xcode 27

### DIFF
--- a/BuddyData/Package.swift
+++ b/BuddyData/Package.swift
@@ -19,7 +19,6 @@ let package = Package(
       .package(path: "../BuddyDomain"),
       .package(path: "../BuddyTestSupport"),
       .package(url: "https://github.com/Moya/Moya.git", .upToNextMajor(from: "15.0.0")),
-      .package(url: "https://github.com/evgenyneu/keychain-swift.git", from: "24.0.0"),
       .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.10.0")),
     ],
     targets: [
@@ -29,7 +28,6 @@ let package = Package(
               "BuddyDomain",
               "Moya",
               "Alamofire",
-              .product(name: "KeychainSwift", package: "keychain-swift"),
             ]
         ),
         .target(name: "BuddyDataWatch", dependencies: [

--- a/BuddyData/Sources/BuddyDataCore/Helper/Keychain.swift
+++ b/BuddyData/Sources/BuddyDataCore/Helper/Keychain.swift
@@ -1,0 +1,98 @@
+//
+//  Keychain.swift
+//  BuddyData
+//
+//  Created by Soongyu Kwon on 10/06/2026.
+//
+
+import Foundation
+import Security
+
+/// A minimal Keychain wrapper for the small subset of functionality the app needs.
+///
+/// Implemented directly on top of the Security framework so we don't depend on an
+/// external keychain package. Items are stored using the same item class
+/// (`kSecClassGenericPassword`) and account attribute (`kSecAttrAccount`) as before,
+/// so values previously written by the old library remain readable.
+public final class Keychain {
+  /// Access group used to share keychain items between the app and its extensions.
+  public var accessGroup: String?
+
+  public init() {}
+
+  @discardableResult
+  public func set(_ value: String, forKey key: String, withAccess access: KeychainAccessOptions? = nil) -> Bool {
+    guard let data = value.data(using: .utf8) else { return false }
+    return set(data, forKey: key, withAccess: access)
+  }
+
+  @discardableResult
+  public func set(_ value: Data, forKey key: String, withAccess access: KeychainAccessOptions? = nil) -> Bool {
+    // Overwrite any existing value for this key.
+    delete(key)
+
+    let accessible = (access ?? .accessibleWhenUnlocked).value
+
+    var query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrAccount as String: key,
+      kSecValueData as String: value,
+      kSecAttrAccessible as String: accessible,
+    ]
+    query = addingAccessGroup(to: query)
+
+    return SecItemAdd(query as CFDictionary, nil) == errSecSuccess
+  }
+
+  public func get(_ key: String) -> String? {
+    guard let data = getData(key) else { return nil }
+    return String(data: data, encoding: .utf8)
+  }
+
+  public func getData(_ key: String) -> Data? {
+    var query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrAccount as String: key,
+      kSecMatchLimit as String: kSecMatchLimitOne,
+      kSecReturnData as String: kCFBooleanTrue as Any,
+    ]
+    query = addingAccessGroup(to: query)
+
+    var result: AnyObject?
+    guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess else { return nil }
+    return result as? Data
+  }
+
+  @discardableResult
+  public func delete(_ key: String) -> Bool {
+    var query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrAccount as String: key,
+    ]
+    query = addingAccessGroup(to: query)
+
+    return SecItemDelete(query as CFDictionary) == errSecSuccess
+  }
+
+  private func addingAccessGroup(to query: [String: Any]) -> [String: Any] {
+    guard let accessGroup else { return query }
+    var query = query
+    query[kSecAttrAccessGroup as String] = accessGroup
+    return query
+  }
+}
+
+/// Keychain item accessibility options, mirroring the subset the app relies on.
+public enum KeychainAccessOptions {
+  /// The data is accessible only while the device is unlocked by the user.
+  case accessibleWhenUnlocked
+  /// The data is accessible after the first unlock following a restart.
+  case accessibleAfterFirstUnlock
+
+  var value: CFString {
+    switch self {
+    case .accessibleWhenUnlocked: return kSecAttrAccessibleWhenUnlocked
+    case .accessibleAfterFirstUnlock: return kSecAttrAccessibleAfterFirstUnlock
+    }
+  }
+}

--- a/BuddyData/Sources/BuddyDataCore/Helper/TokenStorage.swift
+++ b/BuddyData/Sources/BuddyDataCore/Helper/TokenStorage.swift
@@ -7,14 +7,13 @@
 
 import Foundation
 import Combine
-import KeychainSwift
 import BuddyDomain
 
-/// TokenStorage stores non-Sendable types (KeychainSwift, CurrentValueSubject).
+/// TokenStorage stores non-Sendable types (Keychain, CurrentValueSubject).
 /// We assert thread-safety at the call sites and confine usage appropriately.
 /// Use @unchecked Sendable to satisfy protocol conformance under Swift's strict concurrency checking.
 public final class TokenStorage: @unchecked Sendable, TokenStorageProtocol {
-  private let keychain = KeychainSwift()
+  private let keychain = Keychain()
   private static let accessTokenKey = "accessToken"
   private static let refreshTokenKey = "refreshToken"
   private static let tokenExpirationKey = "tokenExpiration"

--- a/BuddyData/Sources/BuddyDataCore/Repository/VersionRepository.swift
+++ b/BuddyData/Sources/BuddyDataCore/Repository/VersionRepository.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import BuddyDomain
-import Version
 
 @preconcurrency
 import Moya

--- a/BuddyDataiOS/Sources/BuddyDataiOS/Service/AnalyticsService.swift
+++ b/BuddyDataiOS/Sources/BuddyDataiOS/Service/AnalyticsService.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import FirebaseAnalytics
-import KeychainSwift
+import BuddyDataCore
 import BuddyDomain
 
 public class AnalyticsService: AnalyticsServiceProtocol {
@@ -19,7 +19,7 @@ public class AnalyticsService: AnalyticsServiceProtocol {
   }
 
   private func getDeviceUUID() -> String {
-    let keychain = KeychainSwift()
+    let keychain = Keychain()
     keychain.accessGroup = "N5V8W52U3U.org.sparcs.soap"
 
     return keychain.get(AnalyticsService.fcmDeviceIDKey) ?? {

--- a/BuddyDataiOS/Sources/BuddyDataiOS/Service/CrashlyticsService.swift
+++ b/BuddyDataiOS/Sources/BuddyDataiOS/Service/CrashlyticsService.swift
@@ -8,7 +8,7 @@
 import Foundation
 import FirebaseCrashlytics
 import BuddyDomain
-import KeychainSwift
+import BuddyDataCore
 
 public final class CrashlyticsService: CrashlyticsServiceProtocol {
   private static let fcmDeviceIDKey: String = "fcmDeviceID"
@@ -76,7 +76,7 @@ public final class CrashlyticsService: CrashlyticsServiceProtocol {
   }
 
   private func getDeviceUUID() -> String {
-    let keychain = KeychainSwift()
+    let keychain = Keychain()
     keychain.accessGroup = "N5V8W52U3U.org.sparcs.soap"
 
     return keychain.get(CrashlyticsService.fcmDeviceIDKey) ?? {

--- a/BuddyDataiOS/Sources/BuddyDataiOS/UseCase/FCMUseCase.swift
+++ b/BuddyDataiOS/Sources/BuddyDataiOS/UseCase/FCMUseCase.swift
@@ -7,11 +7,11 @@
 
 import Foundation
 import BuddyDomain
-import KeychainSwift
+import BuddyDataCore
 import UIKit
 
 public final class FCMUseCase: FCMUseCaseProtocol, @unchecked Sendable {
-  private let keychain = KeychainSwift()
+  private let keychain = Keychain()
   private static let fcmDeviceIDKey: String = "fcmDeviceID"
   
   private let fcmRepository: FCMRepositoryProtocol

--- a/BuddyDomain/Package.swift
+++ b/BuddyDomain/Package.swift
@@ -15,7 +15,6 @@ let package = Package(
         ),
     ],
     dependencies: [
-      .package(url: "https://github.com/mxcl/Version.git", .upToNextMajor(from: "2.2.0")),
       .package(url: "https://github.com/hmlongco/Factory.git", .upToNextMajor(from: "2.5.3"))
     ],
     targets: [
@@ -24,7 +23,6 @@ let package = Package(
         .target(
             name: "BuddyDomain",
             dependencies: [
-              .product(name: "Version", package: "Version"),
               .product(name: "Factory", package: "Factory"),
             ]
         ),

--- a/BuddyDomain/Sources/Model/Version.swift
+++ b/BuddyDomain/Sources/Model/Version.swift
@@ -1,0 +1,63 @@
+//
+//  Version.swift
+//  BuddyDomain
+//
+//  Created by Soongyu Kwon on 10/06/2026.
+//
+
+import Foundation
+
+/// A lightweight semantic version value type.
+///
+/// Provides the small subset of functionality the app needs (parsing,
+/// comparison and a string description) so we don't depend on an external
+/// versioning package.
+public struct Version: Comparable, Hashable, Sendable, CustomStringConvertible {
+  public let major: Int
+  public let minor: Int
+  public let patch: Int
+
+  /// The zero version (`0.0.0`).
+  public static let null = Version(major: 0, minor: 0, patch: 0)
+
+  public init(major: Int, minor: Int, patch: Int = 0) {
+    self.major = major
+    self.minor = minor
+    self.patch = patch
+  }
+
+  /// Parses a dot-separated version string such as `"1.2.3"`, `"1.2"`, or `"3"`.
+  ///
+  /// Any pre-release or build metadata (everything after a `-` or `+`) is
+  /// ignored. Missing components default to zero. Returns `nil` if a present
+  /// component is not a non-negative integer or there are more than three.
+  public init?(_ string: String) {
+    let core = string.prefix { $0 != "-" && $0 != "+" }
+    let components = core.split(separator: ".", omittingEmptySubsequences: false)
+    guard !components.isEmpty, components.count <= 3 else { return nil }
+
+    var values = [0, 0, 0]
+    for (index, component) in components.enumerated() {
+      guard let value = Int(component), value >= 0 else { return nil }
+      values[index] = value
+    }
+    self.init(major: values[0], minor: values[1], patch: values[2])
+  }
+
+  public var description: String {
+    "\(major).\(minor).\(patch)"
+  }
+
+  public static func < (lhs: Version, rhs: Version) -> Bool {
+    (lhs.major, lhs.minor, lhs.patch) < (rhs.major, rhs.minor, rhs.patch)
+  }
+}
+
+public extension Bundle {
+  /// The bundle's short version string (`CFBundleShortVersionString`) parsed as a ``Version``.
+  ///
+  /// Returns ``Version/null`` when the value is absent or unparseable.
+  var version: Version {
+    (infoDictionary?["CFBundleShortVersionString"] as? String).flatMap(Version.init) ?? .null
+  }
+}

--- a/BuddyDomain/Sources/Repository/VersionRepositoryProtocol.swift
+++ b/BuddyDomain/Sources/Repository/VersionRepositoryProtocol.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Version
 
 public protocol VersionRepositoryProtocol: Sendable {
   func getMinimumVersion() async throws -> Version?

--- a/soap.xcodeproj/project.pbxproj
+++ b/soap.xcodeproj/project.pbxproj
@@ -64,7 +64,6 @@
 		8BFAD26F2E92A52D005D8639 /* BuddyDomain in Frameworks */ = {isa = PBXBuildFile; productRef = 8BFAD26E2E92A52D005D8639 /* BuddyDomain */; };
 		F6339A682F544AC600655DBB /* NotificationServiceExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = F6339A612F544AC600655DBB /* NotificationServiceExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		F6339A6E2F544C1E00655DBB /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = F6339A6D2F544C1E00655DBB /* FirebaseMessaging */; };
-		F6C7DAC62F1B2BE4000B32F1 /* Version in Frameworks */ = {isa = PBXBuildFile; productRef = F6C7DAC52F1B2BE4000B32F1 /* Version */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -327,7 +326,6 @@
 				8BCE7E8C2FC1CBAC000368D2 /* ChannelIOSDK in Frameworks */,
 				8B7C19E52E1DAEEB00DB2D21 /* Moya in Frameworks */,
 				8BE539592F2B8A2000735E7A /* BuddyFeatureFeed in Frameworks */,
-				F6C7DAC62F1B2BE4000B32F1 /* Version in Frameworks */,
 				8BE5395B2F2B95A600735E7A /* BuddyFeatureSettings in Frameworks */,
 				8B7C19E32E1DAEEB00DB2D21 /* CombineMoya in Frameworks */,
 				8B89693F2F2CCF8700955B84 /* BuddyFeatureSearch in Frameworks */,
@@ -543,7 +541,6 @@
 				8B8368012E9247A900892B70 /* BuddyDomain */,
 				8BFAD2682E92A3A0005D8639 /* BuddyDataCore */,
 				8B45B2812F161F8100A858F5 /* Haptica */,
-				F6C7DAC52F1B2BE4000B32F1 /* Version */,
 				8BE537AE2F27833F00735E7A /* BuddyDataiOS */,
 				8BE539522F2B767900735E7A /* BuddyFeatureTimetable */,
 				8BE539542F2B775A00735E7A /* BuddyFeatureShared */,
@@ -680,7 +677,6 @@
 				8B6B2B492E2878CD00D13D50 /* XCRemoteSwiftPackageReference "Nuke" */,
 				8B5073DD2E851F79007E9C27 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				8B45B2802F161F8100A858F5 /* XCRemoteSwiftPackageReference "Haptica" */,
-				F6C7DAC42F1B2BE4000B32F1 /* XCRemoteSwiftPackageReference "Version" */,
 				8BCE7E8A2FC1CBAC000368D2 /* XCRemoteSwiftPackageReference "channel-talk-ios-framework" */,
 			);
 			preferredProjectObjectVersion = 77;
@@ -1576,14 +1572,6 @@
 				minimumVersion = 13.1.1;
 			};
 		};
-		F6C7DAC42F1B2BE4000B32F1 /* XCRemoteSwiftPackageReference "Version" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/mxcl/Version";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.2.0;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1783,11 +1771,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 8B5073DD2E851F79007E9C27 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseMessaging;
-		};
-		F6C7DAC52F1B2BE4000B32F1 /* Version */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = F6C7DAC42F1B2BE4000B32F1 /* XCRemoteSwiftPackageReference "Version" */;
-			productName = Version;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/soap.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/soap.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6dbd6ed5ce9c9f737df9d47382d9aed11b1dd1e06455454a283cbe9c31eb8683",
+  "originHash" : "5b074a81b4bafe13898d96c9eafd9ccc96424aea25b1e2bd03cabe5af3186070",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -233,15 +233,6 @@
       "state" : {
         "revision" : "8cba041db09596183331d123f337d0eb2e6e8e91",
         "version" : "2.1.1"
-      }
-    },
-    {
-      "identity" : "version",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mxcl/Version",
-      "state" : {
-        "revision" : "67ce582bb9de70e1eb2ee41fd71aad3b5f86d97b",
-        "version" : "2.2.0"
       }
     }
   ],

--- a/soap.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/soap.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5b074a81b4bafe13898d96c9eafd9ccc96424aea25b1e2bd03cabe5af3186070",
+  "originHash" : "927a68bc640e04c2a6a3d9a4169c4d19da33d852e46a9522940ca0f5cecbee9b",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -125,15 +125,6 @@
       "state" : {
         "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
         "version" : "101.0.0"
-      }
-    },
-    {
-      "identity" : "keychain-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/evgenyneu/keychain-swift.git",
-      "state" : {
-        "revision" : "5e1b02b6a9dac2a759a1d5dbc175c86bd192a608",
-        "version" : "24.0.0"
       }
     },
     {

--- a/soap.xcodeproj/xcshareddata/xcschemes/BuddyWatchWidgetExtension.xcscheme
+++ b/soap.xcodeproj/xcshareddata/xcschemes/BuddyWatchWidgetExtension.xcscheme
@@ -77,7 +77,6 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "8B3FB1192E94F1C200F57FD7"
             BuildableName = "BuddyWatchWidgetExtension.appex"
-            BlueprintName = "BuddyWatchWidgetExtension"
             ReferencedContainer = "container:soap.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
@@ -120,7 +119,6 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "8B3FB1192E94F1C200F57FD7"
             BuildableName = "BuddyWatchWidgetExtension.appex"
-            BlueprintName = "BuddyWatchWidgetExtension"
             ReferencedContainer = "container:soap.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>

--- a/soap.xcodeproj/xcshareddata/xcschemes/WatchBuddy Watch App.xcscheme
+++ b/soap.xcodeproj/xcshareddata/xcschemes/WatchBuddy Watch App.xcscheme
@@ -60,7 +60,6 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "8B8365022E914F1200892B70"
             BuildableName = "WatchBuddy Watch App.app"
-            BlueprintName = "WatchBuddy Watch App"
             ReferencedContainer = "container:soap.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
@@ -77,7 +76,6 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "8B8365022E914F1200892B70"
             BuildableName = "WatchBuddy Watch App.app"
-            BlueprintName = "WatchBuddy Watch App"
             ReferencedContainer = "container:soap.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>

--- a/soap/ContentViewModel.swift
+++ b/soap/ContentViewModel.swift
@@ -10,7 +10,6 @@ import Combine
 import Observation
 import Factory
 import BuddyDomain
-import Version
 
 @Observable
 @MainActor


### PR DESCRIPTION
This pull request removes two external dependencies—`keychain-swift` and `Version`—and replaces them with lightweight, in-house implementations. This reduces reliance on third-party libraries, simplifies dependency management, and keeps only the functionality the app actually uses. The changes include adding a custom `Keychain` wrapper, a simple `Version` struct, and updating all relevant code to use these new implementations.

The most important changes are:

**Dependency Removal and Replacement**

* Removed the `keychain-swift` and `Version` packages from the project and all package manifests, as well as their references from the Xcode project files. [[1]](diffhunk://#diff-1790fd20f891261ca64a37690d7ae07d31f032770210c9d2ca9ed078d3b5a94fL22) [[2]](diffhunk://#diff-b772ad4b7b31feeb49f31faef099a77dc218fadbd837ccd40634cb86f11a8ea4L18) [[3]](diffhunk://#diff-1c8721cfd2cc03247a9ecdfc7d9153a770faa1e1caa910ba0b82d00956400a26L67) [[4]](diffhunk://#diff-1c8721cfd2cc03247a9ecdfc7d9153a770faa1e1caa910ba0b82d00956400a26L546) [[5]](diffhunk://#diff-1c8721cfd2cc03247a9ecdfc7d9153a770faa1e1caa910ba0b82d00956400a26L683) [[6]](diffhunk://#diff-1c8721cfd2cc03247a9ecdfc7d9153a770faa1e1caa910ba0b82d00956400a26L1579-L1586) [[7]](diffhunk://#diff-1c8721cfd2cc03247a9ecdfc7d9153a770faa1e1caa910ba0b82d00956400a26L1787-L1791) [[8]](diffhunk://#diff-06d29ba169260e4b70e9eadd3803aa06903d0de6803997180341d6f5314d08ebL130-L138) [[9]](diffhunk://#diff-06d29ba169260e4b70e9eadd3803aa06903d0de6803997180341d6f5314d08ebL237-L245)

**Keychain Functionality**

* Added a minimal, custom `Keychain` wrapper in `BuddyDataCore` to replace the external `KeychainSwift` dependency. Updated all usages to use the new `Keychain` class. [[1]](diffhunk://#diff-dbe5025d3cd951810a4b880eeb448cbb4b6a0921c0f1470f46983e55b7388e38R1-R98) [[2]](diffhunk://#diff-acab3a9443a013e9224ae1f422ac14ff244ddcd4f55a6f8fe6e2c806ab3e8d92L10-R16) [[3]](diffhunk://#diff-a6df46bf190e3b066795735efc83d43b2c56dc6de6e054d78a0e1a03bd70aefcL10-R10) [[4]](diffhunk://#diff-a6df46bf190e3b066795735efc83d43b2c56dc6de6e054d78a0e1a03bd70aefcL22-R22) [[5]](diffhunk://#diff-3c9c1c2925086c79dafc6bbde156fd28e8eba9602935c520c01d6b59fdc1da60L11-R11) [[6]](diffhunk://#diff-3c9c1c2925086c79dafc6bbde156fd28e8eba9602935c520c01d6b59fdc1da60L79-R79) [[7]](diffhunk://#diff-115e4000d694c37c5ae222d4eb19907894a5d3faf77116014a4bf0516a89dd84L10-R14)

**Version Functionality**

* Added a lightweight `Version` struct in `BuddyDomain` to replace the external `Version` package, including parsing, comparison, and string formatting. Updated all references to use the new struct. [[1]](diffhunk://#diff-dae9f8bc0a24e5f70d725e6927221e1af9d3c9cf92096d87e4f1f73213e88c0aR1-R63) [[2]](diffhunk://#diff-74580ac35946881fc529689f7df09160dbe9cd8fd22b884eae2471334a53da4eL10) [[3]](diffhunk://#diff-135d1e7eaa134ceee15615705d3d0975fc2c18f2a2563d8ad53abe5456678b8dL9) [[4]](diffhunk://#diff-c79fb9bcf843048b44d697d0f67c7d15520ae1c825f7fb5d8601b7ad9be3c75dL13)

**Project Cleanup**

* Removed all references to the deleted packages from Xcode project and workspace files, ensuring a clean build and dependency graph. [[1]](diffhunk://#diff-1c8721cfd2cc03247a9ecdfc7d9153a770faa1e1caa910ba0b82d00956400a26L67) [[2]](diffhunk://#diff-1c8721cfd2cc03247a9ecdfc7d9153a770faa1e1caa910ba0b82d00956400a26L546) [[3]](diffhunk://#diff-1c8721cfd2cc03247a9ecdfc7d9153a770faa1e1caa910ba0b82d00956400a26L683) [[4]](diffhunk://#diff-1c8721cfd2cc03247a9ecdfc7d9153a770faa1e1caa910ba0b82d00956400a26L1579-L1586) [[5]](diffhunk://#diff-1c8721cfd2cc03247a9ecdfc7d9153a770faa1e1caa910ba0b82d00956400a26L1787-L1791) [[6]](diffhunk://#diff-06d29ba169260e4b70e9eadd3803aa06903d0de6803997180341d6f5314d08ebL130-L138) [[7]](diffhunk://#diff-06d29ba169260e4b70e9eadd3803aa06903d0de6803997180341d6f5314d08ebL237-L245)

These changes streamline the codebase, reduce external dependencies, and keep only the necessary functionality for the app.